### PR TITLE
Return PHP parser errors to facilitate debugging scripts

### DIFF
--- a/lib/PHPExpress/engine.js
+++ b/lib/PHPExpress/engine.js
@@ -6,6 +6,7 @@ var path = require('path'),
 var engine = function (filePath, opts, callback) {
     var binPath = this.binPath,
         runnerPath = this.runnerPath,
+        displayErrors = this.displayErrors,
 
         method = opts.method || 'GET',
         get = opts.get || {},
@@ -38,7 +39,13 @@ var engine = function (filePath, opts, callback) {
 
     child_process.exec(command, function (error, stdout, stderr) {
         if (error) {
-            callback(error);
+
+            // can leak server configuration
+            if (displayErrors && stdout) {
+                callback(stdout);
+            } else {
+                callback(error);
+            }
         } else if (stdout) {
             callback(null, stdout);
         } else if (stderr) {

--- a/lib/PHPExpress/index.js
+++ b/lib/PHPExpress/index.js
@@ -4,6 +4,9 @@ var PHPExpress = function (opts) {
     this.binPath = opts.binPath || '/usr/bin/php',
     this.runnerPath = opts.runnerPath || (__dirname + '/../../page_runner.php');
 
+    // default to true for easier PHP debugging
+    this.displayErrors = typeof opts.displayErrors === 'undefined' ? true : opts.displayErrors;
+
     this.engine = require('./engine').bind(this);
     this.router = require('./router').bind(this);
 };


### PR DESCRIPTION
This is a simple change to bubble up any PHP parser errors. The current implementation bubbles up the node js error instead of the output from PHP as to why the process died.