### PR TITLE
parse_strの実行条件を変更

### DIFF
--- a/page_runner.php
+++ b/page_runner.php
@@ -1,6 +1,8 @@
 <?php
   //parse the command line into the $_GET variable
-  parse_str($_SERVER['QUERY_STRING'], $_GET);
+  if ( isset($_SERVER) && array_key_exists('QUERY_STRING', $_SERVER) ) {
+    parse_str($_SERVER['QUERY_STRING'], $_GET);
+  }
 
   //parse the standard input into the $_POST variable
   if (($_SERVER['REQUEST_METHOD'] === 'POST')


### PR DESCRIPTION
$_SERVERに'QUERY_STRING'が定義されている場合のみ実行します。