### PR TITLE
Handle missing callback

### DIFF
--- a/lib/PHPExpress/engine.js
+++ b/lib/PHPExpress/engine.js
@@ -50,6 +50,8 @@ var engine = function (filePath, opts, callback) {
             callback(null, stdout);
         } else if (stderr) {
             callback(stderr);
+        } else {
+            callback(null, null);
         }
     });
 };


### PR DESCRIPTION
Handle case when there is no err, no stdout, and no stderr (example: my php soap server does not returns any output in some calls)