### PR TITLE
Issue #3 fixing export not recognized on windows

### DIFF
--- a/lib/PHPExpress/engine.js
+++ b/lib/PHPExpress/engine.js
@@ -19,25 +19,19 @@ var engine = function (filePath, opts, callback) {
             REQUEST_METHOD: method,
             CONTENT_LENGTH: body.length,
             QUERY_STRING: query
-        },
-        encodedEnv = [];
-
-    for (var key in env) {
-        if (env[key]) {
-            encodedEnv.push(util.format('%s="%s"', key, env[key]));
-        }
-    }
+        };
 
     var command = util.format(
-        '%s %s %s %s %s',
-        encodedEnv.length ? 'export ' + encodedEnv.join(' ') + ';' : '',
+        '%s %s %s %s',
         (body ? util.format('echo "%s" | ', body) : '') + binPath,
         runnerPath,
         path.dirname(filePath),
         filePath
     );
 
-    child_process.exec(command, function (error, stdout, stderr) {
+    child_process.exec(command,{
+		env: env
+	}, function (error, stdout, stderr) {
         if (error) {
 
             // can leak server configuration


### PR DESCRIPTION
moving environment variables from being set on the command line using export to use the child_process env option, should be usable cross platform but needs to be double checked on non windows systems