### PR TITLE
Accept opts.server value in engine.js

### DIFF
--- a/lib/PHPExpress/engine.js
+++ b/lib/PHPExpress/engine.js
@@ -14,11 +14,13 @@ var engine = function (filePath, opts, callback) {
 
         query = opts.query || querystring.stringify(get),
         body = opts.body || querystring.stringify(post),
+	server = querystring.stringify(opts.server || {})
 
         env = {
             REQUEST_METHOD: method,
             CONTENT_LENGTH: body.length,
-            QUERY_STRING: query
+            QUERY_STRING: query,
+	    SERVER: server
         };
 
     var command = util.format(

--- a/lib/PHPExpress/engine.js
+++ b/lib/PHPExpress/engine.js
@@ -22,7 +22,7 @@ var engine = function (filePath, opts, callback) {
             QUERY_STRING: query,
         };
 
-    server.forEach(key => {
+    Object.keys(server).forEach(key => {
       env[key] = server[key]
     });
 

--- a/lib/PHPExpress/engine.js
+++ b/lib/PHPExpress/engine.js
@@ -14,14 +14,17 @@ var engine = function (filePath, opts, callback) {
 
         query = opts.query || querystring.stringify(get),
         body = opts.body || querystring.stringify(post),
-	server = querystring.stringify(opts.server || {})
+	      server = opts.server || {},
 
         env = {
             REQUEST_METHOD: method,
             CONTENT_LENGTH: body.length,
             QUERY_STRING: query,
-	    SERVER: server
         };
+
+    server.forEach(key => {
+      env[key] = server[key]
+    });
 
     var command = util.format(
         '%s %s %s %s',

--- a/lib/PHPExpress/router.js
+++ b/lib/PHPExpress/router.js
@@ -2,6 +2,9 @@ module.exports = function(req, res) {
     res.render(req.path.slice(1), {
         method: req.method,
         get: req.query,
-        post: req.body
+        post: req.body,
+        server: {
+          REQUEST_URI: req.url
+        }
     });
 };

--- a/page_runner.php
+++ b/page_runner.php
@@ -1,15 +1,22 @@
 <?php
-  //parse the command line into the $_GET variable
-  if ( isset($_SERVER) && array_key_exists('QUERY_STRING', $_SERVER) ) {
+
+$REQUEST_METHOD = isset($_SERVER['REQUEST_METHOD']) 
+  ? $_SERVER['REQUEST_METHOD'] : 'GET';
+
+$CONTENT_LENGTH = isset($_SERVER['CONTENT_LENGTH'])
+  ? $_SERVER['CONTENT_LENGTH'] : 0;
+
+//parse the command line into the $_GET variable
+if (isset($_SERVER) && array_key_exists('QUERY_STRING', $_SERVER) ) {
     parse_str($_SERVER['QUERY_STRING'], $_GET);
-  }
+}
 
-  //parse the standard input into the $_POST variable
-  if (($_SERVER['REQUEST_METHOD'] === 'POST')
-   && ($_SERVER['CONTENT_LENGTH'] > 0))
-  {
-    parse_str(fread(STDIN, $_SERVER['CONTENT_LENGTH']), $_POST);
-  }
+//parse the standard input into the $_POST variable
+if (($REQUEST_METHOD === 'POST')
+    && ($CONTENT_LENGTH > 0)
+) {
+    parse_str(fread(STDIN, $CONTENT_LENGTH), $_POST);
+}
 
-  chdir($argv[1]);
-  require_once $argv[2];
+chdir($argv[1]);
+require_once $argv[2];


### PR DESCRIPTION
This pull requests aims to allow additional environment variables to be passed to PHP from Express; explicitly including req.url mapped to REQUEST_URI to help PHP understand more about the request being served.

The change allows:
- `opts.server` to be provided to allow mapping between `req.url` : `REQUEST_URI` from express to the PHPExpress engine